### PR TITLE
Feat/performance subject api

### DIFF
--- a/src/controllers/pointsController.js
+++ b/src/controllers/pointsController.js
@@ -37,6 +37,23 @@ const pointsController = {
       const statusCode = error.status || 500;
       res.status(statusCode).json({ message: error.message });
     }
+  },
+  getPerformanceBySubject: async (req, res) => {
+    try {
+      const { year, month } = req.query;
+      const user = req.user;
+
+      const result = await pointsService.getPerformanceBySubject(
+        user.id,
+        year,
+        month
+      );
+
+      res.status(200).json(result);
+    } catch(error) {
+      const statusCode = error.status || 500;
+      res.status(statusCode).json({ message: error.message });
+    }
   }
 };
 

--- a/src/controllers/pointsController.js
+++ b/src/controllers/pointsController.js
@@ -21,6 +21,23 @@ const pointsController = {
       res.status(statusCode).json({ message: error.message });
     }
   },
+  getUserPerformance: async (req, res) => {
+    try {
+      const { year, discipline } = req.query;
+      const user = req.user;
+
+      const result = await pointsService.getUserPerformance(
+        user.id,
+        year,
+        discipline
+      );
+
+      res.status(200).json(result);
+    } catch(error) {
+      const statusCode = error.status || 500;
+      res.status(statusCode).json({ message: error.message });
+    }
+  }
 };
 
 module.exports = { pointsController };

--- a/src/public/pages/authorized-user/performance/performance.css
+++ b/src/public/pages/authorized-user/performance/performance.css
@@ -1,0 +1,59 @@
+.performance-container {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+.performance-title {
+    color: #0B2072;
+    text-align: center;
+    margin-bottom: 30px;
+    font-size: 2rem;
+}
+
+.filters-container {
+    display: flex;
+    gap: 20px;
+    margin-bottom: 30px;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.filter-label {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    font-weight: bold;
+    color: #333;
+}
+
+.filter-select {
+    padding: 8px 12px;
+    border: 1px solid #0B2072;
+    border-radius: 5px;
+    background-color: white;
+    font-size: 1rem;
+}
+
+.chart-container {
+    width: 100%;
+    height: 400px;
+    margin-bottom: 30px;
+}
+
+@media (max-width: 768px) {
+    .filters-container {
+        flex-direction: column;
+        align-items: center;
+    }
+    
+    .filter-label {
+        width: 100%;
+        max-width: 300px;
+    }
+    
+    .filter-select {
+        width: 100%;
+    }
+}

--- a/src/public/pages/authorized-user/performance/performance.js
+++ b/src/public/pages/authorized-user/performance/performance.js
@@ -1,0 +1,106 @@
+import Header from "/components/headerWithMenu.js";
+import { renderFooter } from "/components/footer.js";
+import Chart from 'chart.js/auto';
+
+function PerformancePage() {
+    const element = document.createElement("div");
+    element.style.height = "100vh";
+    element.style.display = "flex";
+    element.style.flexDirection = "column";
+
+    //Header
+    element.appendChild(Header());
+
+    //Main content
+    const main = document.createElement("main");
+    main.style.flex = "1";
+    main.style.padding = "20px";
+    main.style.display = "flex";
+    main.style.flexDirection = "column";
+    main.style.alignItems = "center";
+
+    //Title
+    const title = document.createElement("h1");
+    title.textContent = "Evolução do Desempenho";
+    text.style.color = "#0b2072";
+    title.style.marginBottom = "30px";
+    main.appendChild(title);
+
+    //Filter
+    const filtersContainer = document.createElement("div");
+    filtersContainer.style.display = "flex";
+    filtersContainer.style.gap = "20px";
+    filtersContainer.style.marginBottom = "30px";
+    filtersContainer.style.flexWrap = "wrap";
+    filtersContainer.style.justifyContent = "center";
+
+    //Year filter
+    const yearLabel = document.createElement("label");
+    yearLabel.textContent = "Ano";
+    const yearSelect = document.createElement("select");
+    yearSelect.id = "yearFilter";
+    yearSelect.style.padding = "8px";
+    yearSelect.style.borderRadius = "5px";
+    yearSelect.style.border = "1px solid #0B2072";
+
+    //Add year options - 2025 as default
+    const years = [2014, 2015, 2016];
+    years.forEach(year => {
+        const option = document.createElement("option");
+        option.value = year;
+        option.textContent = year;
+        if (year === 2015) option.selected = true;
+        yearSelect.appendChild(option);
+    });
+
+    yearLabel.appendChild(yearSelect);
+    filtersContainer.appendChild(yearLabel);
+
+    //Discipline filter
+    const disciplineLabel = document.createElement("label");
+    disciplineLabel.textContent = "Matéria";
+    const disciplineSelect = document.createElement("select");
+    disciplineSelect.id = "disciplineFilter";
+    disciplineSelect.style.padding = "8px";
+    disciplineSelect.style.borderRadius = "5px";
+    disciplineSelect.style.border = "1px solid #0B2072";
+
+    const disciplines = [
+        { value: "all", text: "Todas" },
+        { value: "matematica", text: "Matemática" },
+        { value: "linguagens", text: "Linguagens" },
+        { value: "ciencias-humanas", text: "Ciências Humanas" },
+        { value: "ciencias-natureza", text: "Ciências da Natureza" }
+    ];
+
+    disciplines.forEach(discipline => {
+        const option = document.createElement("option");
+        option.value = discipline.value;
+        option.textContent = discipline.text;
+        disciplineSelect.appendChild(option);
+    });
+
+    disciplineLabel.appendChild(disciplineSelect);
+    filtersContainer.appendChild(disciplineLabel);
+
+    main.appendChild(filtersContainer);
+
+    //Chart
+    const chartContainer = document.createElement("div");
+    chartContainer.style.width = "90%";
+    chartContainer.style.maxWidth = "800px";
+    chartContainer.style.height = "400px";
+    chartContainer.style.marginBottom = "30px";
+
+    const canvas = document.createElement("canvas");
+    canvas.id = "performanceChart";
+    chartContainer.appendChild(canvas);
+    main.appendChild(chartContainer);
+
+    element.appendChild(main);
+    element.appendChild(renderFooter());
+
+    return element;
+}
+
+export default PerformancePage;

--- a/src/public/pages/authorized-user/performance/performance.js
+++ b/src/public/pages/authorized-user/performance/performance.js
@@ -105,15 +105,25 @@ function PerformancePage() {
 
     async function loadPerformanceData(year, discipline) {
         try {
-            const response = await fetch(`/api/performance?year=${year}&discipline=${discipline}`, {
-                credentials: 'include'
-            });
-
-            if (!response.ok) {
-                throw new Error('Failed to fetch performance data');
+            const url = new URL('/api/performance', window.location.origin);
+            url.searchParams.append('year', year);
+            if (discipline !== 'all') {
+                url.searchParams.append('discipline', discipline);
             }
 
-            return await response.json();
+            if (!response.ok) {
+                throw new Error('Error: ${response.status}');
+            }
+
+            const data = await response.json();
+
+            //Transform data if needed
+            return data.map(item => ({
+                ...item,
+                month: new Date(item.month) //Ensure month is Date object
+            }));
+
+
         } catch(error) {
             console.error('Error loading performance data: ', error);
             return [];

--- a/src/repositories/pointsRepository.js
+++ b/src/repositories/pointsRepository.js
@@ -1,4 +1,5 @@
 const { pool } = require("../config/db");
+const { param } = require("../routes/pointsRoutes");
 const { examRepository } = require("./examRepository");
 const { userRepository } = require("./userRepository");
 
@@ -80,6 +81,40 @@ const pointsRepository = {
       throw error;
     }
   },
+  getPerformanceBySubject: async (userId, year, month) => {
+    try {
+      let query = `
+        SELECT
+          q.discipline,
+          qa.is_correct,
+          DATA_TRUNC('month', aq.answered_at) as month
+        FROM accounts_questions aq
+        JOIN questions q ON aq.id_question = q.id
+        JOIN question_alternatives qa ON aq.id_alternative = qa.id
+        WHERE aq.id_account = $1
+      `;
+
+      const params = [userId];
+      let paramIndex = 2;
+
+      if (year && year !== 'all') {
+        query += ` AND EXTRACT(YEAR FROM aq.answered_at) = $${paramIndex}`;
+        params.push(year);
+        paramIndex++;
+      }
+
+      if (month && month !== 'all') {
+        query += ` AND EXTRACT(MONTH FROM aq.answered_at) = $${paramIndex}`;
+        params.push(year);
+        paramIndex++;
+      }
+
+      const result = await pool.query(query, params);
+      return result.rows;
+    } catch (error) {
+      throw error;
+    }
+  }
 };
 
 module.exports = { pointsRepository };

--- a/src/routes/pointsRoutes.js
+++ b/src/routes/pointsRoutes.js
@@ -4,5 +4,6 @@ const { authToken } = require("../middlewares/authMiddleware.js");
 
 router.get("/points", authToken, pointsController.getPointsByUser);
 router.get("/leaderboard", authToken, pointsController.getAllUserPoints);
+router.get("/performance", authToken, pointsController.getUserPerformance);
 
 module.exports = router;

--- a/src/services/pointsService.js
+++ b/src/services/pointsService.js
@@ -59,6 +59,31 @@ const pointsService = {
     } catch(error) {
       throw error;
     }
+  },
+  getPerformanceBySubject: async (userId, year, month) => {
+    try {
+      const result = await pointsRepository.getPerformanceBySubject(
+        userId,
+        year,
+        month
+      );
+
+      //Calculate right answers percentages by subjects
+      const subjects = ['matematica', 'linguagens', 'ciencias-humanas', 'ciencias-natureza'];
+      const performance = {};
+
+      subjects.forEach(subject => {
+        const subjectData = result.filter(item => item.discipline === subject);
+        const total = subjectData.length;
+        const correct = subjectData.filter(item => item.is_correct).length;
+
+        performance[subject] = total > 0 ? Math.round((correct / total) * 100) : 0;
+      });
+
+      return performance;
+    } catch(error) {
+      throw error;
+    }
   }
 };
 

--- a/src/services/pointsService.js
+++ b/src/services/pointsService.js
@@ -19,6 +19,47 @@ const pointsService = {
       throw error;
     }
   },
+  getUserPerformance: async (userId, year, discipline) => {
+    try {
+      let query = `
+        SELECT
+          DATE_TRUNC('month', aq.answered_at) AS month,
+          q.discipline,
+          COUNT(CASE WHEN qa.is_correct THEN 1 END) AS correct_answers,
+          COUNT(*) AS total_answers,
+          (COUNT(CASE WHEN qa.is_correct THEN 1 END) * 100.0 / COUNT(*)) AS accuracy_percentage
+        FROM accounts_questions aq
+        JOIN questions q ON aq.id_question = q.id
+        JOIN question_alternatives qa ON aq.id_alternative = qa.id
+        WHERE aq.id_account = $1
+      `;
+
+      const params = [userId];
+      let paramIndex = 2;
+
+      if(year) {
+        query += ` AND EXTRACT(YEAR FROM aq.answered_at) = $${paramIndex}`;
+        params.oush(year);
+        paramIndex++;
+      }
+
+      if (discipline && discipline !== 'all') {
+        query += ` AND q.discipline = $${paramIndex}`;
+        params.push(discipline);
+        paramIndex++;
+      }
+
+      query += `
+        GOUP BY month, q.discipline
+        ORDER BY month, q.discipline
+      `;
+
+      const result = await pool.query(query, params);
+      return result.rows;
+    } catch(error) {
+      throw error;
+    }
+  }
 };
 
 module.exports = { pointsService };


### PR DESCRIPTION
This PR adds a new API endpoint to fetch user performance data grouped by subject. The endpoint accepts optional year and month filters and returns the percentage of correct answers for each of the 4 main ENEM subjects.